### PR TITLE
feat: add modal component with typewriter error effect

### DIFF
--- a/src/components/ModalCrush/ModalCrush.module.css
+++ b/src/components/ModalCrush/ModalCrush.module.css
@@ -1,0 +1,56 @@
+.crushContainer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  color: #0f0;
+  z-index: 1000;
+  display: flex;
+  font-family: 'Courier New', monospace;
+  padding: 2rem;
+}
+
+.close{
+  background-color: #000;
+  border: none;
+  box-shadow: none;
+}
+
+.terminal {
+  display: flex;
+  background-color: #000;
+  color: #0f0;
+  font-family: 'Courier New', monospace;
+  white-space: pre-wrap;
+  line-height: 1.4;
+  font-size: 2rem;
+  max-width: 800px;
+  width: 100%;
+   align-items: center;
+  justify-content: center;
+}
+
+.terminalText {
+  display: inline;
+}
+
+.cursor {
+  display: inline-block;
+  background-color: #0f0;
+  width: 8px;
+  height: 1.2em;
+  margin-left: 2px;
+  animation: blink 0.8s infinite;
+  vertical-align: middle;
+}
+
+@keyframes blink {
+  0%, 50% {
+    opacity: 1;
+  }
+  51%, 100% {
+    opacity: 0;
+  }
+}

--- a/src/components/ModalCrush/ModalCrush.tsx
+++ b/src/components/ModalCrush/ModalCrush.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import styles from "./ModalCrush.module.css";
+
+type ModalCrushProps = {
+  crush: boolean;
+  setCrush: (value: boolean) => void; 
+  era?: { error?: string }; 
+};
+
+export default function ModalCrush({ crush, setCrush, era }: ModalCrushProps) {
+  const [displayText, setDisplayText] = useState("");
+  const [isTypingComplete, setIsTypingComplete] = useState(false);
+
+  useEffect(() => {
+    if (crush) {
+      const scrollY = window.scrollY;
+
+      document.body.style.overflow = "hidden";
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.left = "0";
+      document.body.style.right = "0";
+
+      return () => {
+        document.body.style.overflow = "";
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.left = "";
+        document.body.style.right = "";
+
+        window.scrollTo(0, scrollY);
+      };
+    }
+  }, [crush]);
+
+  const useTypewriter = (text: string, speed: number = 40) => {
+    useEffect(() => {
+      setDisplayText("");
+      setIsTypingComplete(false);
+
+      let index = 0;
+      const timer = setInterval(() => {
+        if (index < text.length) {
+          setDisplayText((prev) => prev + text.charAt(index));
+          index++;
+        } else {
+          setIsTypingComplete(true);
+          clearInterval(timer);
+        }
+      }, speed);
+
+      return () => clearInterval(timer);
+    }, [text, speed]);
+  };
+
+  useTypewriter(era?.error || "", 60);
+
+  return (
+    <>
+      (
+      <div className={styles.crushContainer}>
+        <button className={styles.close} onClick={() => setCrush(false)}>
+          <img src="/close-icon.svg" alt="" />
+        </button>
+        <div className={styles.terminal}>
+          <span className={styles.terminalText}>{displayText}</span>
+          {!isTypingComplete && <span className={styles.cursor}>|</span>}
+        </div>
+      </div>
+      )
+    </>
+  );
+}


### PR DESCRIPTION
Create ModalCrush component to display a modal window.
- Lock page scroll when modal is open.
- Implement typewriter effect to show error text from era.error prop.
- Add close button to dismiss modal.
- Manage display text and cursor state locally.