### PR TITLE
feat: implement dynamic lazy-loaded routing for era pages

### DIFF
--- a/src/pages/Eras/ErasPages.tsx
+++ b/src/pages/Eras/ErasPages.tsx
@@ -1,0 +1,35 @@
+import { lazy, Suspense } from "react"
+import { useParams } from "react-router-dom";
+
+const eraComponents = {
+  "1969": lazy(() => import("./Year1969/Year1969")),
+  "1983": lazy(() => import("./Year1983/Year1983")),
+  "1990": lazy(() => import("./Year1990/Year1990")),
+  "1993": lazy(() => import("./Year1993/Year1993")),
+  "1995": lazy(() => import("./Year1995/1995Year")),
+  "2004": lazy(() => import("./Year2004/Year2004")),
+  "2006": lazy(() => import("./Year2006/Year2006")),
+} as const;
+
+type EraYear = keyof typeof eraComponents;
+
+
+export default function Eras(){
+    const { year } = useParams<{ year: string }>();
+
+    const Component = year && year in eraComponents ? eraComponents[year as EraYear] : null;
+
+  if (!Component) {
+    return (
+      <div style={{ padding: "50px", textAlign: "center" }}>
+        Год <strong>{year}</strong> ещё не готов или не найден
+      </div>
+    );
+  }
+
+    return(
+        <Suspense>
+            <Component/>
+        </Suspense>
+    )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,14 +4,7 @@ import Home from "./pages/Home/Home";
 import Timeline from "./pages/Timeline/Timeline";
 import { About } from "./pages/About/About";
 import { Gallery } from "./pages/Gallery/Gallery";
-
-import Year1983 from "./pages/Eras/Year1983/Year1983";
-import Year1990 from "./pages/Eras/Year1990/Year1990";
-import Year1993 from "./pages/Eras/Year1993/Year1993";
-import Year1995 from "./pages/Eras/Year1995/1995Year";
-import Year2004 from "./pages/Eras/Year2004/Year2004";
-import Year2006 from "./pages/Eras/Year2006/Year2006";
-import Year1969 from "./pages/Eras/Year1969/Year1969";
+import Eras from "./pages/Eras/ErasPages";
 
 export const router = createBrowserRouter([
   {
@@ -27,32 +20,8 @@ export const router = createBrowserRouter([
         element: <Timeline />,
       },
       {
-        path: "/eras/1969",
-        element: <Year1969 />,
-      },
-      {
-        path: "/eras/1983",
-        element: <Year1983 />,
-      },
-      {
-        path: "/eras/1990",
-        element: <Year1990 />,
-      },
-      {
-        path: "/eras/1993",
-        element: <Year1993 />,
-      },
-      {
-        path: "/eras/1995",
-        element: <Year1995 />,
-      },
-      {
-        path: "/eras/2004",
-        element: <Year2004 />,
-      },
-      {
-        path: "/eras/2006",
-        element: <Year2006 />,
+        path: "/eras/:year",
+        element: <Eras />,
       },
       {
         path: "/gallery",


### PR DESCRIPTION
- Replaced multiple static year routes with a single dynamic route: /eras/:year
- Created EraPage component to handle dynamic routing based on URL parameter
- Implemented React.lazy() for all era page components
- Added <Suspense> fallback to show loading UI while components load
- Removed individual year routes from router to simplify routing structure
- Ensured unknown years display a 'not found' message
- Improved maintainability and optimized bundle size